### PR TITLE
TST: add bare-bones testing

### DIFF
--- a/test_periodic.py
+++ b/test_periodic.py
@@ -1,0 +1,35 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+import pytest
+
+from cyclic_interpolate import (cyclic_interp_curve,
+        cubic_spline_interpolation_first_derivatives)
+
+
+def make_spline(x, y):
+    # A convenience wrapper for the ctor.
+    # FIXME: this should likely be the API
+    der = cubic_spline_interpolation_first_derivatives(x, y)
+    return cyclic_interp_curve(x, y, der)
+
+
+def test_non_periodic():
+    x = np.arange(8)
+    y = np.arange(8)
+    
+    with pytest.raises(ValueError):
+        make_spline(x, y)     # first and last points differ
+    
+    
+
+def test_random(): 
+    rndm = np.random.RandomState(1234)
+    npts = 8
+    x = np.sort(rndm.uniform(size=8))
+    y = np.random.uniform(size=8)
+    y[-1] = y[0]
+
+    spl = make_spline(x, y)
+    ynew = [spl(_) for _ in x]
+    assert_allclose(ynew, y, atol=1e-12)


### PR DESCRIPTION
From the command line, use:

```
$ python -m pytest test_periodic.py
```
The main idea being that there's a battery of automated tests, and you can tell that your tweaks did not break things by just running them all at once with pytest. 

Probably there's not much point perfecting it for this initial chunk of work. Later though, all new functionality will need to be covered by tests. E.g. the scipy CubicSpline bug we discussed the other day: you'll need to add a regression test based on the issue description and provide a fix. 